### PR TITLE
Feat/social login

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,6 +2,11 @@
   "extends": ["next/core-web-vitals", "plugin:prettier/recommended"],
   "plugins": ["prettier"],
   "rules": {
-    "prettier/prettier": "error"
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ]
   }
 }

--- a/src/app/auth/naver/callback/route.ts
+++ b/src/app/auth/naver/callback/route.ts
@@ -43,7 +43,9 @@ export async function GET(request: Request) {
   if (user) {
     const provider = user.app_metadata?.provider;
     if (provider === 'kakao') {
-      return NextResponse.redirect(`${process.env.NEXT_PUBLIC_SITE_URL}/?social=${provider}`);
+      return NextResponse.redirect(
+        `${process.env.NEXT_PUBLIC_SITE_URL}/signin?error=social_conflict&provider=${provider}`,
+      );
     }
   } else {
     const { data: signUpData, error: signUpError } = await supabaseAdmin.auth.signUp({

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,3 @@
-'use client';
-import { handleAuthCallback } from '@/utils/auth/authCallbackhandler';
-import { useRouter } from 'next/navigation';
-import { useEffect } from 'react';
-
 export default function Home() {
-  const router = useRouter();
-
-  useEffect(() => {
-    handleAuthCallback(router);
-  }, []);
-
   return <div>홈</div>;
 }

--- a/src/app/signin/page.tsx
+++ b/src/app/signin/page.tsx
@@ -1,7 +1,16 @@
 'use client';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { handleAuthCallback } from '@/utils/auth/authCallbackhandler';
 import { handleGoogleSignIn, handleKakaoSignIn, handleNaverSignIn } from '@/utils/supabase/singIn';
 
 const SigInPage = () => {
+  const router = useRouter();
+
+  useEffect(() => {
+    handleAuthCallback(router);
+  }, []);
+
   return (
     <div className='flex flex-col gap-10'>
       <button onClick={handleGoogleSignIn}>구글 로그인</button>

--- a/src/utils/auth/authCallbackhandler.ts
+++ b/src/utils/auth/authCallbackhandler.ts
@@ -1,12 +1,12 @@
 import { AppRouterInstance } from 'next/dist/shared/lib/app-router-context.shared-runtime';
-import { handleKakaoSignIn } from '../supabase/singIn';
 
 export const handleAuthCallback = async (router: AppRouterInstance) => {
   const searchParams = new URLSearchParams(window.location.search);
-  const social = searchParams.get('social');
+  const error = searchParams.get('error');
+  const provider = searchParams.get('provider');
 
-  if (social === 'kakao') {
-    handleKakaoSignIn();
+  if (error === 'social_conflict' && provider === 'kakao') {
+    alert('이미 다른 소셜 계정(카카오)으로 가입된 이메일입니다!');
+    router.replace('/signin');
   }
-  router.replace('/');
 };


### PR DESCRIPTION
## ✅ 작업 사항

- EOL(lf/crlf) 일관성 위한 린트 추가
- 해당 이메일의 provider가 카카오로 존재할 경우
  임시로 카카오 로그인으로 넘겨버림 -> 경고창 + 로그인 페이지로 이동

<br/>

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/d379026a-faf2-4ae5-b3a1-0936f093581c)
<br/>
![image](https://github.com/user-attachments/assets/7f344a06-7785-4234-a890-ce6a3b92beb3)
<br/>
