### PR TITLE
feat: 챌린지 페이지 아이콘 및 이미지 추가, 인증하기 버튼 시안에 맞게 하단 고정

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,15 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = {
+  reactStrictMode: true,
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'henszvzcktnwvspttjvo.supabase.co',
+        pathname: '/storage/v1/object/public/challenges/**',
+      },
+    ],
+  },
+};
 
 export default nextConfig;

--- a/src/app/challenge/[id]/proof/page.tsx
+++ b/src/app/challenge/[id]/proof/page.tsx
@@ -6,10 +6,15 @@ import ChallengeProofHeader from '@/components/challenge/proof/ChallengeProofHea
 import BottomSheet from '@/components/ui/bottomsheet/BottomSheet';
 import useChallenge from '@/hooks/queries/useChallenge';
 import { useChallengeComplete } from '@/hooks/queries/useChallengeComplete';
+import { useEffect } from 'react';
 
 const ChallengeProofPage = () => {
   const { data, isLoading } = useChallenge();
   const { handleCompleteChallenge } = useChallengeComplete(data?.todoChallenge ?? null);
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
 
   if (isLoading || !data) return '로딩 중입니다..';
   return (

--- a/src/app/challenge/layout.tsx
+++ b/src/app/challenge/layout.tsx
@@ -6,7 +6,7 @@ export default async function ChallengeLayout({ children }: { children: React.Re
       <section className='flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[284px] rounded-[61px] bg-primary-100 px-[41px] pb-[33px]'>
         <h1 className='pt-[72px] desktop:pt-[110px] text-[18px] font-semibold text-center'>챌린지</h1>
       </section>
-      <main className='mt-[30px] flex flex-col gap-[50px]'>{children}</main>
+      <main className='mt-[30px] flex flex-col'>{children}</main>
     </div>
   );
 }

--- a/src/app/challenge/page.tsx
+++ b/src/app/challenge/page.tsx
@@ -6,6 +6,7 @@ import ChallengeDetail from '@/components/challenge/ChallengeDetail';
 import useChallenge from '@/hooks/queries/useChallenge';
 import { useChallengeSelect } from '@/hooks/queries/useChallengeSelect';
 import { useChallengeConfirm } from '@/hooks/queries/useChallengeConfirm';
+import ProofButton from '@/components/challenge/proof/ProofButton';
 
 const ChallengePage = () => {
   const { data, isLoading } = useChallenge();
@@ -21,6 +22,7 @@ const ChallengePage = () => {
         challenges={data?.challenges}
         onSelectChallenge={onSelectChallenge}
       />
+      {data.todoChallenge && <ProofButton todoChallenge={data.todoChallenge} />}
       <BottomSheet
         onClick={handleConfirmChallenge}
         disabled={!!data?.todoChallenge}

--- a/src/components/challenge/ChallengeCard.tsx
+++ b/src/components/challenge/ChallengeCard.tsx
@@ -4,6 +4,7 @@ import useBottomSheetStore from '@/stores/useBottomSheetStore';
 import React from 'react';
 
 import { Challenge } from '@/types/challenge.types';
+import Image from 'next/image';
 
 type ChallengeCardProps = {
   challenge: Challenge;
@@ -19,8 +20,14 @@ const ChallengeCard = ({ challenge, onSelectChallenge }: ChallengeCardProps) => 
         onSelectChallenge(challenge.id);
         open();
       }}
-      className='flex items-center w-[333px] h-[74px] px-[16px] py-[13px] bg-[#CADEF5]/[0.39] rounded-[14px] shadow-custom cursor-pointer'
+      className='flex items-center gap-[9px] w-[333px] h-[74px] px-[16px] py-[13px] bg-[#CADEF5]/[0.39] rounded-[14px] shadow-custom cursor-pointer'
     >
+      <Image
+        src={challenge.icon_url}
+        alt={`${challenge.title} 아이콘`}
+        height={39}
+        width={39}
+      />
       <p className='font-medium'>{challenge.title}</p>
     </div>
   );

--- a/src/components/challenge/ChallengeDetail.tsx
+++ b/src/components/challenge/ChallengeDetail.tsx
@@ -1,16 +1,26 @@
+import Image from 'next/image';
+
 type ChallengeDetailProps = {
   title: string;
   description: string;
+  image_url: string;
   tip: string;
 };
 
-const ChallengeDetail = ({ title, description, tip }: ChallengeDetailProps) => {
+const ChallengeDetail = ({ title, description, image_url, tip }: ChallengeDetailProps) => {
   return (
     <div className='flex flex-col justify-between items-center font-pretendard text-center h-[357px] mt-[5px]'>
       <h1 className='font-semibold text-[20px] mb-[14px] leading-[35px]'>{title}</h1>
       <div className='h-[342px] flex flex-col items-center justify-around'>
         <h3 className='font-medium text-[12px] mb-[18px] w-[345px] leading-[20px]'>{`"${description}"`}</h3>
-        <div className='w-[197px] h-[197px] bg-[#D9D9D9]' />
+        <div className='w-[284px] h-[190px] relative'>
+          <Image
+            src={image_url}
+            alt={`${title} 이미지`}
+            fill
+            className='object-contain'
+          />
+        </div>
         <p className='mt-[10px] font-medium text-[12px] mb-[9px] w-[345px]'>
           <span className='text-primary-400'>💡Tip</span>
           <span className='text-neutral-500'> {tip}</span>

--- a/src/components/challenge/TodoChallengeCard.tsx
+++ b/src/components/challenge/TodoChallengeCard.tsx
@@ -2,8 +2,8 @@ import { Challenge } from '@/types/challenge.types';
 import React from 'react';
 import Button from '../ui/buttons/Button';
 
-import Modal from '../ui/modal/Modal';
 import { useChallengeProofCheck } from '@/hooks/queries/useChallengeProofCheck';
+import Image from 'next/image';
 
 type TodoChallengeCardProps = {
   todoChallenge: Challenge | null;
@@ -11,30 +11,24 @@ type TodoChallengeCardProps = {
 };
 
 const TodoChallengeCard = ({ todoChallenge, showProofButton }: TodoChallengeCardProps) => {
-  const { handleChallengeProofCheck } = useChallengeProofCheck(todoChallenge ?? null);
-
   return (
     <>
       <div className='mt-[5px] w-[333px] h-[74px] px-[16px] py-[13px] border border-primary-400 rounded-[14px] shadow-custom bg-neutral-70'>
         <p className='text-[10px] font-medium text-neutral-900'>오늘의 챌린지</p>
-        <div className='flex justify-between'>
-          <h2 className='font-medium leading-[35px]'>
-            {todoChallenge ? todoChallenge.title : '아직 참여중인 챌린지가 없습니다.'}
-          </h2>
-          {todoChallenge && showProofButton && (
-            <Button
-              onClick={handleChallengeProofCheck}
-              size='small'
-              variant='primary'
-            >
-              인증
-            </Button>
-          )}
-        </div>
+        {todoChallenge ? (
+          <div className='flex items-center gap-[9px]'>
+            <Image
+              src={todoChallenge.icon_url}
+              alt={`${todoChallenge.title} 아이콘`}
+              height={39}
+              width={39}
+            />
+            <h2 className='font-medium leading-[35px]'>{todoChallenge.title}</h2>
+          </div>
+        ) : (
+          <h2>아직 참여중인 챌린지가 없습니다.</h2>
+        )}
       </div>
-      <Modal>
-        <p className='font-semibold mb-[10px]'>오늘의 챌린지를 완료했습니다! </p>
-      </Modal>
     </>
   );
 };

--- a/src/components/challenge/TodoChallengeCard.tsx
+++ b/src/components/challenge/TodoChallengeCard.tsx
@@ -26,7 +26,7 @@ const TodoChallengeCard = ({ todoChallenge, showProofButton }: TodoChallengeCard
             <h2 className='font-medium leading-[35px]'>{todoChallenge.title}</h2>
           </div>
         ) : (
-          <h2>아직 참여중인 챌린지가 없습니다.</h2>
+          <h2 className='font-medium leading-[35px]'>아직 참여중인 챌린지가 없습니다.</h2>
         )}
       </div>
     </>

--- a/src/components/challenge/proof/CarbonEmissionResult.tsx
+++ b/src/components/challenge/proof/CarbonEmissionResult.tsx
@@ -14,7 +14,7 @@ const CarbonEmissionResult = ({ todoChallenge }: CarbonEmissionResultProps) => {
     <section className='mt-[160px] mb-[10px]'>
       <h1 className='text-[18px] font-semibold leading-[35px]'>탄소계산</h1>
 
-      <div className='flex flex-col gap-[39px] mt-[11px]'>
+      <div className='flex flex-col gap-[39px] mt-[11px] mb-[50px]'>
         <div className='flex flex-col items-center w-[333px] h-[268px] bg-primary-100 rounded-[14px] pt-[22px] shadow-custom'>
           <p className='text-[16px] font-medium text-[#4A4A68] leading-[35px] mb-[12px]'>
             내가 아낀 탄소를 확인해보세요!

--- a/src/components/challenge/proof/ProofButton.tsx
+++ b/src/components/challenge/proof/ProofButton.tsx
@@ -1,0 +1,31 @@
+import Button from '@/components/ui/buttons/Button';
+import Modal from '@/components/ui/modal/Modal';
+import { useChallengeProofCheck } from '@/hooks/queries/useChallengeProofCheck';
+import { Challenge } from '@/types/challenge.types';
+
+type ProofButton = {
+  todoChallenge: Challenge;
+};
+
+const ProofButton = ({ todoChallenge }: ProofButton) => {
+  const { handleChallengeProofCheck } = useChallengeProofCheck(todoChallenge ?? null);
+
+  return (
+    <>
+      <div className='mt-[83px] mb-[50px]'>
+        <Button
+          onClick={handleChallengeProofCheck}
+          size='xlarge'
+          variant='primary'
+        >
+          인증하기
+        </Button>
+      </div>
+      <Modal>
+        <p className='font-semibold mb-[10px]'>오늘의 챌린지를 완료했습니다! </p>
+      </Modal>
+    </>
+  );
+};
+
+export default ProofButton;

--- a/src/types/challenge.types.ts
+++ b/src/types/challenge.types.ts
@@ -2,8 +2,8 @@ export type Challenge = {
   id: number;
   title: string;
   description: string;
-  icon_url: string | null;
-  image_url: string | null;
+  icon_url: string;
+  image_url: string;
   tip: string;
   carbon_emissions: number;
 };


### PR DESCRIPTION
## ✅ 작업 사항

- 챌린지 페이지 아이콘 및 이미지 추가, 인증하기 버튼 시안에 맞게 하단 고정

<br/>

## 📸 스크린샷
챌린지 페이지
![챌린지 페이지](https://github.com/user-attachments/assets/014ed1a0-e514-4238-a37a-f21d97f58c82)
<br/>
챌린지 바텀시트
![챌린지 바텀시트](https://github.com/user-attachments/assets/9302df48-1ce0-403a-a9fd-3c780c8e8400)

<br/>