### PR TITLE
Feat/mobile onboarding link: 모바일 온보딩 페이지 시작 경로 수정, 스타일 수정

### DIFF
--- a/src/app/(header-title-layout)/page.tsx
+++ b/src/app/(header-title-layout)/page.tsx
@@ -1,12 +1,13 @@
 import MobileOnboarding from '@/components/onboarding/MobileOnboarding';
 import DesktopOnboarding from '@/components/onboarding/DesktopOnboarding';
 import { getIsSignedIn } from '@/utils/supabase/auth';
+import { MOBILE_HEADER_HEIGHT } from '@/constants/layoutInfo';
 
 export default async function Home() {
   const isSignedIn = await getIsSignedIn();
 
   return (
-    <div className='w-full h-full'>
+    <div className={`w-full h-[calc(100vh-${MOBILE_HEADER_HEIGHT}px)] desktop:h-full`}>
       <MobileOnboarding isSignedIn={isSignedIn} />
       <DesktopOnboarding />
     </div>

--- a/src/app/(header-title-layout)/page.tsx
+++ b/src/app/(header-title-layout)/page.tsx
@@ -1,10 +1,13 @@
 import MobileOnboarding from '@/components/onboarding/MobileOnboarding';
 import DesktopOnboarding from '@/components/onboarding/DesktopOnboarding';
+import { getIsSignedIn } from '@/utils/supabase/auth';
 
-export default function Home() {
+export default async function Home() {
+  const isSignedIn = await getIsSignedIn();
+
   return (
     <div className='w-full h-full'>
-      <MobileOnboarding />
+      <MobileOnboarding isSignedIn={isSignedIn} />
       <DesktopOnboarding />
     </div>
   );

--- a/src/components/onboarding/MobileOnboarding.tsx
+++ b/src/components/onboarding/MobileOnboarding.tsx
@@ -11,6 +11,10 @@ import MobileFixedEllipseBackground from '../background/MobileFixedEllipseBackgr
 import Link from 'next/link';
 import Button from '../ui/buttons/Button';
 
+type MobileOnboardingProps = {
+  isSignedIn: boolean;
+};
+
 const ONBOARDING_DATA: { description: string; image: string | null }[] = [
   { description: '탄소 절감을 실천하기 어려우셨나요?', image: '/assets/images/onboarding/mobile-onboarding-1.png' },
   { description: '데일리 에코 챌린지를 완료하면', image: '/assets/images/onboarding/mobile-onboarding-2.png' },
@@ -18,8 +22,10 @@ const ONBOARDING_DATA: { description: string; image: string | null }[] = [
   { description: '친구와의 랭킹까지 확인할 수 있어요!', image: '/assets/images/onboarding/mobile-onboarding-4.png' },
 ];
 
-export default function MobileOnboarding() {
+export default function MobileOnboarding({ isSignedIn }: MobileOnboardingProps) {
   SwiperCore.use([Navigation, Pagination]);
+  const startButtonRoute = isSignedIn ? '/challenge' : '/signin';
+
   return (
     <div className='w-full h-full py-[30px] pb-[60px] desktop:hidden'>
       <Swiper
@@ -45,7 +51,7 @@ export default function MobileOnboarding() {
               </div>
               <div className='flex justify-center items-centerw-full h-[48px]'>
                 {index === ONBOARDING_DATA.length - 1 && (
-                  <Link href='/signin'>
+                  <Link href={startButtonRoute}>
                     <Button
                       size='medium'
                       variant='primary'

--- a/src/constants/layoutInfo.ts
+++ b/src/constants/layoutInfo.ts
@@ -1,0 +1,1 @@
+export const MOBILE_HEADER_HEIGHT = 70;


### PR DESCRIPTION
## ✅ 작업 사항

- 로그인 후 세션이 존재하는 경우 시작하기 버튼이 '/challenge'로 이동하도록 수정
- 로그인하지 않은 경우 기존 '/signin' 경로로 이동
- 모바일 헤더 높이를 상수로 분리해 모바일 온보딩 페이지 높이를 계산

<br/>

## 📸 스크린샷
<img width="424" alt="image" src="https://github.com/user-attachments/assets/9ea777dc-b3a8-4390-969d-75779ca260f6" />

- 로그인한 경우 챌린지 페이지로 이동
![로그인한 경우 챌린지 페이지로 이동](https://github.com/user-attachments/assets/501cc8a8-594d-43ad-bfcf-66ca19b5b363)

- 로그인하지 않은 경우 챌린지 페이지로 이동
![로그인하지 않은 경우 로그인 페이지로 이동](https://github.com/user-attachments/assets/fb01f570-9d6f-4bed-890e-e80acc557829)

<br/>

## 🧑‍💻 기타

- 레이아웃이 계산해서 배치하는 것들이 좀 있어서 그 값들 상수파일로 모으면 좋을 것 같아요!!
