### PR TITLE
Feat/challenge

### DIFF
--- a/src/app/challenge/layout.tsx
+++ b/src/app/challenge/layout.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export default async function ChallengeLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className='desktop:flex desktop:justify-center desktop:bg-primary-100/[36%] desktop:min-h-screen'>
+    <div className='desktop:flex desktop:justify-center desktop:bg-primary-100/[36%] desktop:min-h-screen mx-auto'>
       <section className='desktop:hidden flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[284px] rounded-[61px] bg-primary-100 px-[41px] pb-[33px] z-10'>
         <h1 className='pt-[72px] text-[18px] font-semibold text-center'>챌린지</h1>
       </section>

--- a/src/app/challenge/layout.tsx
+++ b/src/app/challenge/layout.tsx
@@ -4,7 +4,7 @@ export default async function ChallengeLayout({ children }: { children: React.Re
   return (
     <div className='desktop:flex desktop:justify-center desktop:bg-primary-100/[36%] desktop:min-h-screen mx-auto'>
       <section className='desktop:hidden flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[284px] rounded-[61px] bg-primary-100 px-[41px] pb-[33px] z-10'>
-        <h1 className='pt-[72px] text-[18px] font-semibold text-center'>챌린지</h1>
+        <h1 className='pt-[65px] text-[18px] font-semibold text-center'>챌린지</h1>
       </section>
       <main className='mt-[30px] desktop:mt-[63px] flex flex-col h-full desktop:w-desktop desktop:px-[20px] mb-[50px]'>
         {children}

--- a/src/app/challenge/layout.tsx
+++ b/src/app/challenge/layout.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 export default async function ChallengeLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className='desktop:flex desktop:justify-center desktop:bg-primary-100/[36%] desktop:min-h-screen'>
-      <section className='desktop:hidden flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[284px] rounded-[61px] bg-primary-100 px-[41px] pb-[33px]'>
+      <section className='desktop:hidden flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[284px] rounded-[61px] bg-primary-100 px-[41px] pb-[33px] z-10'>
         <h1 className='pt-[72px] text-[18px] font-semibold text-center'>챌린지</h1>
       </section>
       <main className='mt-[30px] desktop:mt-[63px] flex flex-col h-full desktop:w-desktop desktop:px-[20px] mb-[50px]'>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -37,7 +37,7 @@ const Header = () => {
 
       <div
         onClick={toggleMenu}
-        className={`fixed right-0 top-[48px] pr-[21px] desktop:hidden z-[12]`}
+        className={`fixed right-0 top-[41px] pr-[21px] desktop:hidden z-[12]`}
       >
         <Image
           src={MenuIcon}

--- a/src/components/challenge/ChallengeHeader.tsx
+++ b/src/components/challenge/ChallengeHeader.tsx
@@ -8,7 +8,7 @@ type ChallengeHeaderProps = {
 
 const ChallengeHeader = ({ todoChallenge }: ChallengeHeaderProps) => {
   return (
-    <section className='fixed desktop:relative flex flex-col z-5'>
+    <section className='fixed desktop:relative flex flex-col z-10'>
       <div className='px-[3px]'>
         <h2 className='text-[18px] desktop:text-[40px] font-semibold'>내가 참여중인 챌린지</h2>
         <p className='text-[10px] desktop:text-[20px] font-medium text-primary-400'>

--- a/src/components/challenge/ChallengeList.tsx
+++ b/src/components/challenge/ChallengeList.tsx
@@ -13,7 +13,7 @@ const ChallengeList = ({ challenges, onSelectChallenge }: ChallengeListProps) =>
       <h1 className='text-[18px] desktop:text-[40px] font-semibold leading-[35px] desktop:leading-[60px]'>
         데일리 에코 챌린지
       </h1>
-      <p className='text-[12px] desktop:text-[20px] font-medium text-[#4A4A68] desktop:text-primary-400'>
+      <p className='text-[12px] desktop:text-[20px] font-medium text-primary-400'>
         챌린지를 누르면 방법을 확인 할 수 있어요!
       </p>
       <div className='flex flex-col desktop:flex-row justify-center gap-[19px] desktop:gap-[139px] mt-[15px] desktop:mt-[93px]'>


### PR DESCRIPTION
## ✅ 작업 사항

-style: 챌린지 페이지 헤더 z-index추가, 모바일, 데스크탑 동일한 폰트 색상으로 통일, 챌린지 페이지 레이아웃 mx-auto 추가, 모바일 헤더 높이 수정
<br/>

## 📸 스크린샷
아이콘 겹치는 현상 해결 및 가운데 정렬
![아이콘 겹치는 현상 해결 및 가운데 정렬](https://github.com/user-attachments/assets/c026bcbc-5c45-488c-87c5-e7acaa44ac14)

<br/>

## 🧑‍💻 기타

- 기존 헤더 높이보다 7px 줄이도록!
