### PR TITLE
Style/friend button position: 친구추가버튼, 랭킹 아이템 스타일 조정

### DIFF
--- a/src/app/(rankingFriendsTab)/layout.tsx
+++ b/src/app/(rankingFriendsTab)/layout.tsx
@@ -1,10 +1,6 @@
 import RankingFriendsPageTab from '@/components/ranking/RankingFriendsPageTab';
-import FriendUrlCopyButton from '@/components/ui/buttons/FriendUrlCopyButton';
-import { getCurrentUserData } from '@/utils/supabase/auth';
 
 export default async function ChallengeLayout({ children }: { children: React.ReactNode }) {
-  const currentUser = await getCurrentUserData();
-
   return (
     <div className='flex flex-col w-full h-full'>
       <section className='flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[151px] rounded-[61px] bg-primary-100 px-[41px] pb-[33px] z-[-9] desktop:hidden'>
@@ -17,7 +13,6 @@ export default async function ChallengeLayout({ children }: { children: React.Re
         </div>
         <main className='flex flex-col flex-1 gap-[50px]'>{children}</main>
       </div>
-      <FriendUrlCopyButton currentUserId={currentUser?.id} />
     </div>
   );
 }

--- a/src/app/(rankingFriendsTab)/ranking/page.tsx
+++ b/src/app/(rankingFriendsTab)/ranking/page.tsx
@@ -1,5 +1,6 @@
 import FriendsList from '@/components/ranking/FriendsList';
 import Ranking from '@/components/ranking/Ranking';
+import FriendUrlCopyButton from '@/components/ui/buttons/FriendUrlCopyButton';
 import { getCurrentUserData } from '@/utils/supabase/auth';
 
 export default async function page() {
@@ -9,6 +10,7 @@ export default async function page() {
     <>
       <div className='desktop:hidden'>
         <Ranking currentUser={currentUser} />
+        <FriendUrlCopyButton currentUserId={currentUser.id} />
       </div>
       <div className='hidden desktop:flex flex-col justify-start items-center bg-primary-100/70 h-full pt-[80px]'>
         <div className='w-[1200px] flex flex-col justify-center items-start'>
@@ -19,6 +21,7 @@ export default async function page() {
           <Ranking currentUser={currentUser} />
           <FriendsList />
         </div>
+        <FriendUrlCopyButton currentUserId={currentUser.id} />
       </div>
     </>
   );

--- a/src/components/ui/buttons/FriendUrlCopyButton.tsx
+++ b/src/components/ui/buttons/FriendUrlCopyButton.tsx
@@ -18,7 +18,7 @@ export default function FriendUrlCopyButton({ currentUserId }: FriendUrlCopyButt
   return (
     <button
       onClick={handleCopyFriendUrl}
-      className='fixed bottom-[85px] left-1/2 -translate-x-1/2 bg-primary-300 w-[339px] desktop:w-[1035px] h-[68px] desktop:h-[164px] flex justify-around desktop:justify-center items-center rounded-[8px] desktop:rounded-[30px] desktop:px-[90px] shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)]'
+      className='bg-primary-300 w-[339px] desktop:w-[1035px] h-[68px] desktop:h-[164px] flex justify-around desktop:justify-center items-center rounded-[8px] desktop:rounded-[30px] desktop:px-[90px] my-[20px] desktop:my-[64px] shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)]'
     >
       <Image
         src='/assets/icons/pola-head.png'


### PR DESCRIPTION
## ✅ 작업 사항

- 친구추가버튼 position fixed -> relative로 변경
- 친구추가버튼 y축 margin 설정
- 랭킹 아이템 (각 사용자의 순위) 내부 요소 동일한 위치에 배치되도록 등수, 마일리지 부분에 너비 지정 (기존에는 두 요소의 글자수 차이에따라 배치가 달라짐)

<br/>

## 📸 스크린샷

<br/>

## 🧑‍💻 기타

-
