### PR TITLE
Style/ranking-main-layout: 랭킹페이지, 소개 페이지 스타일 수정

### DIFF
--- a/src/app/(header-title-layout)/page.tsx
+++ b/src/app/(header-title-layout)/page.tsx
@@ -9,7 +9,7 @@ export default async function Home() {
   return (
     <div
       className={`w-full desktop:h-full`}
-      style={{ height: `calc(100vh - ${MOBILE_HEADER_HEIGHT}px)` }}
+      style={{ height: `calc(100dvh - ${MOBILE_HEADER_HEIGHT}px)` }}
     >
       <MobileOnboarding isSignedIn={isSignedIn} />
       <DesktopOnboarding />

--- a/src/app/(rankingFriendsTab)/layout.tsx
+++ b/src/app/(rankingFriendsTab)/layout.tsx
@@ -11,7 +11,7 @@ export default async function ChallengeLayout({ children }: { children: React.Re
           <RankingFriendsPageTab href='/ranking' />
           <RankingFriendsPageTab href='/friends' />
         </div>
-        <main className='flex flex-col flex-1 gap-[50px]'>{children}</main>
+        <main className='flex flex-col items-center flex-1 gap-[50px]'>{children}</main>
       </div>
     </div>
   );

--- a/src/app/(rankingFriendsTab)/layout.tsx
+++ b/src/app/(rankingFriendsTab)/layout.tsx
@@ -6,12 +6,12 @@ export default async function ChallengeLayout({ children }: { children: React.Re
       <section className='flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[151px] rounded-[61px] bg-primary-100 px-[41px] pb-[33px] z-[-9] desktop:hidden'>
         <h1 className='pt-[60px] text-[18px] font-semibold text-center leading-[35px]'>랭킹</h1>
       </section>
-      <div className='flex flex-col w-full h-full mt-[58px]'>
-        <div className='flex w-full desktop:hidden'>
+      <div className='flex flex-col w-full h-full'>
+        <div className='flex w-full sticky top-[131px] bg-white z-[9] desktop:hidden'>
           <RankingFriendsPageTab href='/ranking' />
           <RankingFriendsPageTab href='/friends' />
         </div>
-        <main className='flex flex-col items-center flex-1 gap-[50px]'>{children}</main>
+        <main className='flex flex-col items-center flex-1 gap-[50px] z-[-10] mt-[54px]'>{children}</main>
       </div>
     </div>
   );

--- a/src/app/(rankingFriendsTab)/layout.tsx
+++ b/src/app/(rankingFriendsTab)/layout.tsx
@@ -3,6 +3,7 @@ import RankingFriendsPageTab from '@/components/ranking/RankingFriendsPageTab';
 export default async function ChallengeLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className='flex flex-col w-full h-full'>
+      <div className='desktop:hidden fixed top-0 left-1/2 transform -translate-x-1/2 w-full h-[151px] bg-white z-[-10]' />
       <section className='flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[151px] rounded-[61px] bg-primary-100 px-[41px] pb-[33px] z-[-9] desktop:hidden'>
         <h1 className='pt-[60px] text-[18px] font-semibold text-center leading-[35px]'>랭킹</h1>
       </section>
@@ -11,7 +12,7 @@ export default async function ChallengeLayout({ children }: { children: React.Re
           <RankingFriendsPageTab href='/ranking' />
           <RankingFriendsPageTab href='/friends' />
         </div>
-        <main className='flex flex-col items-center flex-1 gap-[50px] z-[-10] mt-[54px] desktop:mt-0'>{children}</main>
+        <main className='flex flex-col items-center flex-1 gap-[50px] z-[-11] mt-[54px] desktop:mt-0'>{children}</main>
       </div>
     </div>
   );

--- a/src/app/(rankingFriendsTab)/layout.tsx
+++ b/src/app/(rankingFriendsTab)/layout.tsx
@@ -11,7 +11,7 @@ export default async function ChallengeLayout({ children }: { children: React.Re
           <RankingFriendsPageTab href='/ranking' />
           <RankingFriendsPageTab href='/friends' />
         </div>
-        <main className='flex flex-col items-center flex-1 gap-[50px] z-[-10] mt-[54px]'>{children}</main>
+        <main className='flex flex-col items-center flex-1 gap-[50px] z-[-10] mt-[54px] desktop:mt-0'>{children}</main>
       </div>
     </div>
   );

--- a/src/app/(rankingFriendsTab)/ranking/page.tsx
+++ b/src/app/(rankingFriendsTab)/ranking/page.tsx
@@ -17,7 +17,7 @@ export default async function page() {
           <h2 className='text-[40px] font-semibold text-neutral-1000 w-full'>랭킹 확인</h2>
           <p className='text-[20px] font-medium text-primary-400 w-full'>나와 친구들의 랭킹을 확인해보세요!</p>
         </div>
-        <div className='flex flex-row justify-center items-start gap-[48px] w-[1200px]'>
+        <div className='flex flex-row justify-between items-start gap-[48px] w-[1200px]'>
           <Ranking currentUser={currentUser} />
           <FriendsList />
         </div>

--- a/src/app/(rankingFriendsTab)/ranking/page.tsx
+++ b/src/app/(rankingFriendsTab)/ranking/page.tsx
@@ -7,7 +7,7 @@ export default async function page() {
   const currentUser = await getCurrentUserData();
 
   return (
-    <>
+    <div className='w-full'>
       <div className='desktop:hidden'>
         <Ranking currentUser={currentUser} />
         <FriendUrlCopyButton currentUserId={currentUser.id} />
@@ -23,6 +23,6 @@ export default async function page() {
         </div>
         <FriendUrlCopyButton currentUserId={currentUser.id} />
       </div>
-    </>
+    </div>
   );
 }

--- a/src/components/ranking/FriendsList.tsx
+++ b/src/components/ranking/FriendsList.tsx
@@ -28,12 +28,21 @@ export default function FriendsList() {
     return <div className='text-center py-4 w-full'>친구 정보를 불러오고 있습니다...</div>;
   }
 
+  const NoFriendsMessage = () => <div className='text-center py-4'>추가된 친구가 없습니다.</div>;
+
   if (friends.length === 0) {
-    return <div className='text-center py-4'>추가된 친구가 없습니다.</div>;
+    return (
+      <div className='hidden desktop:block w-full desktop:rounded-[40px] desktop:shadow-[4px_4px_4px_0px_rgba(0,0,0,0.15)] desktop:bg-white desktop:px-[20px] desktop:py-[27px] desktop:mt-[36px]'>
+        <div className='hidden desktop:block'>
+          <h2 className='text-[24px] text-neutral-1000 font-semibold mb-[12px]'>추가한 친구</h2>
+        </div>
+        <NoFriendsMessage />
+      </div>
+    );
   }
 
   return (
-    <div className='flex flex-col w-full desktop:w-[364px] desktop:rounded-[40px] desktop:shadow-[4px_4px_4px_0px_rgba(0,0,0,0.15)] desktop:bg-white desktop:px-[20px] desktop:py-[27px] desktop:mt-[36px]'>
+    <div className='flex flex-col w-full desktop:rounded-[40px] desktop:shadow-[4px_4px_4px_0px_rgba(0,0,0,0.15)] desktop:bg-white desktop:px-[20px] desktop:py-[27px] desktop:mt-[36px]'>
       <div className='hidden desktop:block'>
         <h2 className='text-[24px] text-neutral-1000 font-semibold mb-[12px]'>추가한 친구</h2>
       </div>

--- a/src/components/ranking/RankingItem.tsx
+++ b/src/components/ranking/RankingItem.tsx
@@ -12,9 +12,9 @@ export default function RankingItem({ rankUser, rank, currentUser }: RankingItem
 
   return (
     <div
-      className={`${isCurrentUser ? 'bg-gradient-to-r from-[#5996E09E] from-62% to-white desktop:to-white/40 text-neutral-900' : 'bg-white desktop:bg-transparent text-neutral-1000/20 desktop:text-neutral-500'} flex flex-row justify-between items-center w-full desktop:w-[810px] h-[42px] desktop:h-[92px] desktop:px-[60px] px-[12px] py-[14px] desktop:py-[33px] border-b-[1px] border-[#9EA2AD4D]/30 text-[14px] desktop:text-[20px] font-semibold`}
+      className={`${isCurrentUser ? 'bg-gradient-to-r from-[#5996E09E] from-62% to-white desktop:to-white/40 text-neutral-900' : 'bg-white desktop:bg-transparent text-neutral-1000/20 desktop:text-neutral-500'} flex flex-row justify-between items-center w-full desktop:w-[810px] h-[42px] desktop:h-[92px] px-[12px] desktop:px-[25px] py-[14px] desktop:py-[33px] border-b-[1px] border-[#9EA2AD4D]/30 text-[14px] desktop:text-[20px] font-semibold`}
     >
-      <span className={`${isCurrentUser && 'text-primary-400'} w-[50px] desktop:w-[60px]`}>{rank}</span>
+      <span className={`${isCurrentUser && 'text-primary-400'} w-[50px]`}>{rank}</span>
       <div className='flex-1 flex flex-row gap-[8px] justify-start items-center desktop:w-[520px]'>
         <span className='block w-[244px] desktop:w-fit'>{nickname}</span>
         <span className='hidden desktop:block'>LV.{level}</span>

--- a/src/components/ranking/RankingItem.tsx
+++ b/src/components/ranking/RankingItem.tsx
@@ -12,7 +12,7 @@ export default function RankingItem({ rankUser, rank, currentUser }: RankingItem
 
   return (
     <div
-      className={`${isCurrentUser ? 'bg-gradient-to-r from-[#5996E09E] from-62% to-white desktop:to-white/40 text-neutral-900' : 'bg-white desktop:bg-transparent text-neutral-1000/20 desktop:text-neutral-500'} flex flex-row justify-between items-center w-[339px] desktop:w-[810px] h-[42px] desktop:h-[92px] px-[12px] desktop:px-[60px] py-[14px] desktop:py-[33px] border-b-[1px] border-[#9EA2AD4D]/30 text-[14px] desktop:text-[20px] font-semibold`}
+      className={`${isCurrentUser ? 'bg-gradient-to-r from-[#5996E09E] from-62% to-white desktop:to-white/40 text-neutral-900' : 'bg-white desktop:bg-transparent text-neutral-1000/20 desktop:text-neutral-500'} flex flex-row justify-between items-center w-full desktop:w-[810px] h-[42px] desktop:h-[92px] px-[12px] desktop:px-[60px] py-[14px] desktop:py-[33px] border-b-[1px] border-[#9EA2AD4D]/30 text-[14px] desktop:text-[20px] font-semibold`}
     >
       <span className={`${isCurrentUser && 'text-primary-400'} w-[40px] desktop:w-[60px]`}>{rank}</span>
       <div className='flex-1 flex flex-row gap-[8px] justify-start items-center desktop:w-[520px]'>

--- a/src/components/ranking/RankingItem.tsx
+++ b/src/components/ranking/RankingItem.tsx
@@ -12,9 +12,9 @@ export default function RankingItem({ rankUser, rank, currentUser }: RankingItem
 
   return (
     <div
-      className={`${isCurrentUser ? 'bg-gradient-to-r from-[#5996E09E] from-62% to-white desktop:to-white/40 text-neutral-900' : 'bg-white desktop:bg-transparent text-neutral-1000/20 desktop:text-neutral-500'} flex flex-row justify-between items-center w-full desktop:w-[810px] h-[42px] desktop:h-[92px] px-[12px] desktop:px-[60px] py-[14px] desktop:py-[33px] border-b-[1px] border-[#9EA2AD4D]/30 text-[14px] desktop:text-[20px] font-semibold`}
+      className={`${isCurrentUser ? 'bg-gradient-to-r from-[#5996E09E] from-62% to-white desktop:to-white/40 text-neutral-900' : 'bg-white desktop:bg-transparent text-neutral-1000/20 desktop:text-neutral-500'} flex flex-row justify-between items-center w-full desktop:w-[810px] h-[42px] desktop:h-[92px] desktop:px-[60px] px-[12px] py-[14px] desktop:py-[33px] border-b-[1px] border-[#9EA2AD4D]/30 text-[14px] desktop:text-[20px] font-semibold`}
     >
-      <span className={`${isCurrentUser && 'text-primary-400'} w-[40px] desktop:w-[60px]`}>{rank}</span>
+      <span className={`${isCurrentUser && 'text-primary-400'} w-[50px] desktop:w-[60px]`}>{rank}</span>
       <div className='flex-1 flex flex-row gap-[8px] justify-start items-center desktop:w-[520px]'>
         <span className='block w-[244px] desktop:w-fit'>{nickname}</span>
         <span className='hidden desktop:block'>LV.{level}</span>

--- a/src/components/ranking/RankingItem.tsx
+++ b/src/components/ranking/RankingItem.tsx
@@ -14,12 +14,12 @@ export default function RankingItem({ rankUser, rank, currentUser }: RankingItem
     <div
       className={`${isCurrentUser ? 'bg-gradient-to-r from-[#5996E09E] from-62% to-white desktop:to-white/40 text-neutral-900' : 'bg-white desktop:bg-transparent text-neutral-1000/20 desktop:text-neutral-500'} flex flex-row justify-between items-center w-[339px] desktop:w-[810px] h-[42px] desktop:h-[92px] px-[12px] desktop:px-[60px] py-[14px] desktop:py-[33px] border-b-[1px] border-[#9EA2AD4D]/30 text-[14px] desktop:text-[20px] font-semibold`}
     >
-      <span className={isCurrentUser ? 'text-primary-400' : ''}>{rank}</span>
-      <div className='flex flex-row gap-[8px] justify-start items-center desktop:w-[520px]'>
+      <span className={`${isCurrentUser && 'text-primary-400'} w-[40px] desktop:w-[60px]`}>{rank}</span>
+      <div className='flex-1 flex flex-row gap-[8px] justify-start items-center desktop:w-[520px]'>
         <span className='block w-[244px] desktop:w-fit'>{nickname}</span>
         <span className='hidden desktop:block'>LV.{level}</span>
       </div>
-      <span>{mileage}M</span>
+      <span className='w-[100px] desktop:w-[120px] text-right'>{mileage}M</span>
     </div>
   );
 }

--- a/src/components/ui/buttons/FriendUrlCopyButton.tsx
+++ b/src/components/ui/buttons/FriendUrlCopyButton.tsx
@@ -18,7 +18,7 @@ export default function FriendUrlCopyButton({ currentUserId }: FriendUrlCopyButt
   return (
     <button
       onClick={handleCopyFriendUrl}
-      className='bg-primary-300 w-[339px] desktop:w-[1035px] h-[68px] desktop:h-[164px] flex justify-around desktop:justify-center items-center rounded-[8px] desktop:rounded-[30px] desktop:px-[90px] my-[20px] desktop:my-[64px] shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)]'
+      className='bg-primary-300 w-full desktop:w-[1035px] h-[68px] desktop:h-[164px] flex justify-around desktop:justify-center items-center rounded-[8px] desktop:rounded-[30px] desktop:px-[90px] my-[20px] desktop:my-[64px] shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)]'
     >
       <Image
         src='/assets/icons/pola-head.png'


### PR DESCRIPTION
## ✅ 작업 사항

- 모바일 소개 페이지 인디케이터 제대로 보일 수 있도록 dvh 단위 사용으로 변경
- 랭킹페이지 가운데 정렬 문제 해결
- 모바일 랭킹페이지에서 랭킹/친구확인 탭은 목록과 함께 스크롤되지 않도록 sticky 설정
- 랭킹페이지 내부 요소들이 main 영역을 넘어서지 않도록 내부 요소들 width 조절
- 랭킹페이지 데스크탑 사이즈에서 친구가 없는 경우 문구와 함께 컨테이너가 보이도록 추가

<br/>

## 📸 스크린샷
<img width="1281" alt="image" src="https://github.com/user-attachments/assets/7ef1fc3b-745c-409e-9a52-c75509c1280b" />

![스크롤 확인](https://github.com/user-attachments/assets/55844060-d596-49f8-a647-fe5fb1595765)



<br/>

## 🧑‍💻 기타

-
