### PR TITLE
Style/ranking: 랭킹 페이지 개선사항 적용

### DIFF
--- a/src/app/(rankingFriendsTab)/layout.tsx
+++ b/src/app/(rankingFriendsTab)/layout.tsx
@@ -3,7 +3,7 @@ import RankingFriendsPageTab from '@/components/ranking/RankingFriendsPageTab';
 export default async function ChallengeLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className='flex flex-col w-full h-full'>
-      <section className='flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[151px] rounded-[61px] bg-primary-100 px-[41px] pb-[33px] z-[-9] desktop:hidden'>
+      <section className='flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[151px] rounded-[61px] bg-primary-100 px-[41px] pb-[33px] z-[1] desktop:hidden'>
         <h1 className='pt-[60px] text-[18px] font-semibold text-center leading-[35px]'>랭킹</h1>
       </section>
       <div className='relative flex flex-col w-full h-full mt-[46px] desktop:mt-0'>

--- a/src/app/(rankingFriendsTab)/layout.tsx
+++ b/src/app/(rankingFriendsTab)/layout.tsx
@@ -6,8 +6,8 @@ export default async function ChallengeLayout({ children }: { children: React.Re
       <section className='flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[151px] rounded-[61px] bg-primary-100 px-[41px] pb-[33px] z-[-9] desktop:hidden'>
         <h1 className='pt-[60px] text-[18px] font-semibold text-center leading-[35px]'>랭킹</h1>
       </section>
-      <div className='flex flex-col w-full h-full mt-[58px]'>
-        <div className='flex w-full desktop:hidden'>
+      <div className='relative flex flex-col w-full h-full mt-[46px] desktop:mt-0'>
+        <div className='flex sticky top-[131px] w-full desktop:hidden'>
           <RankingFriendsPageTab href='/ranking' />
           <RankingFriendsPageTab href='/friends' />
         </div>

--- a/src/app/(rankingFriendsTab)/ranking/page.tsx
+++ b/src/app/(rankingFriendsTab)/ranking/page.tsx
@@ -12,12 +12,12 @@ export default async function page() {
         <Ranking currentUser={currentUser} />
         <FriendUrlCopyButton currentUserId={currentUser.id} />
       </div>
-      <div className='hidden desktop:flex flex-col justify-start items-center bg-primary-100/70 h-full pt-[80px]'>
+      <div className='hidden desktop:flex flex-col justify-start items-center bg-primary-100/70 h-full min-h-[calc(100vh-167px)] pt-[80px]'>
         <div className='w-[1200px] flex flex-col justify-center items-start'>
           <h2 className='text-[40px] font-semibold text-neutral-1000 w-full'>랭킹 확인</h2>
           <p className='text-[20px] font-medium text-primary-400 w-full'>나와 친구들의 랭킹을 확인해보세요!</p>
         </div>
-        <div className='flex flex-row justify-center items-start gap-[48px] w-[1200px]'>
+        <div className='flex flex-row justify-between items-start w-[1200px]'>
           <Ranking currentUser={currentUser} />
           <FriendsList />
         </div>

--- a/src/components/ranking/FriendContainer.tsx
+++ b/src/components/ranking/FriendContainer.tsx
@@ -1,0 +1,10 @@
+export default function FriendContainer({ children }: { children: React.ReactNode }) {
+  return (
+    <div className='flex flex-col w-full desktop:w-[364px] desktop:rounded-[40px] desktop:shadow-[4px_4px_4px_0px_rgba(0,0,0,0.15)] desktop:bg-white desktop:px-[20px] desktop:py-[27px] desktop:mt-[36px]'>
+      <div className='hidden desktop:block'>
+        <h2 className='text-[24px] text-neutral-1000 font-semibold mb-[12px]'>추가한 친구</h2>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/src/components/ranking/FriendsList.tsx
+++ b/src/components/ranking/FriendsList.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { UserType } from '@/types/user.types';
 import { getUserFriendsData } from '@/utils/supabase/user';
 import FriendItem from './FriendItem';
+import FriendContainer from './FriendContainer';
 
 export default function FriendsList() {
   const [friends, setFriends] = useState<UserType[]>([]);
@@ -29,14 +30,15 @@ export default function FriendsList() {
   }
 
   if (friends.length === 0) {
-    return <div className='text-center py-4'>추가된 친구가 없습니다.</div>;
+    return (
+      <FriendContainer>
+        <div className='text-center py-4'>추가된 친구가 없습니다.</div>
+      </FriendContainer>
+    );
   }
 
   return (
-    <div className='flex flex-col w-full desktop:w-[364px] desktop:rounded-[40px] desktop:shadow-[4px_4px_4px_0px_rgba(0,0,0,0.15)] desktop:bg-white desktop:px-[20px] desktop:py-[27px] desktop:mt-[36px]'>
-      <div className='hidden desktop:block'>
-        <h2 className='text-[24px] text-neutral-1000 font-semibold mb-[12px]'>추가한 친구</h2>
-      </div>
+    <FriendContainer>
       {friends.map((friend, index) => (
         <FriendItem
           key={friend.id}
@@ -44,6 +46,6 @@ export default function FriendsList() {
           index={index + 1}
         />
       ))}
-    </div>
+    </FriendContainer>
   );
 }

--- a/src/components/ranking/Ranking.tsx
+++ b/src/components/ranking/Ranking.tsx
@@ -48,8 +48,8 @@ export default function Ranking({ currentUser }: RankingProps) {
   };
 
   return (
-    <div className='flex flex-col items-center w-full desktop:w-[812px]'>
-      <div className='flex flex-row w-full h-[14px] justify-start items-center gap-[4px] my-[7px] desktop:my-[12px]'>
+    <div className='flex flex-col items-center w-full'>
+      <div className='flex flex-row w-full h-[14px] justify-start items-center gap-[4px] mt-[14px] ml-[16px] desktop:my-[12px]'>
         <RankingTab
           currentTab={currentTab}
           type='total'

--- a/src/components/ranking/Ranking.tsx
+++ b/src/components/ranking/Ranking.tsx
@@ -49,7 +49,7 @@ export default function Ranking({ currentUser }: RankingProps) {
 
   return (
     <div className='flex flex-col items-center w-full'>
-      <div className='flex flex-row w-full h-[14px] justify-start items-center gap-[4px] mt-[14px] ml-[16px] desktop:my-[12px]'>
+      <div className='flex flex-row w-full h-[14px] justify-start items-center gap-[4px] mt-[14px] ml-[16px] desktop:ml-0 desktop:my-[12px]'>
         <RankingTab
           currentTab={currentTab}
           type='total'

--- a/src/components/ranking/Ranking.tsx
+++ b/src/components/ranking/Ranking.tsx
@@ -48,7 +48,7 @@ export default function Ranking({ currentUser }: RankingProps) {
   };
 
   return (
-    <div className='flex flex-col items-center w-full'>
+    <div className='flex flex-col items-center w-full desktop:w-[810px]'>
       <div className='flex flex-row w-full h-[14px] justify-start items-center gap-[4px] mt-[14px] ml-[16px] desktop:ml-0 desktop:my-[12px]'>
         <RankingTab
           currentTab={currentTab}

--- a/src/components/ranking/RankingFriendsPageTab.tsx
+++ b/src/components/ranking/RankingFriendsPageTab.tsx
@@ -16,7 +16,7 @@ export default function RankingFriendsPageTab({ href }: RankingFriendsPageTabPro
       {href === '/ranking' && (
         <Link
           href='/ranking'
-          className={`text-[18px] font-semibold w-1/2 h-[52px] border-b-[2px] text-center leading-[52px] ${
+          className={`text-[18px] font-semibold w-1/2 h-[52px] border-b-[2px] text-center leading-[52px] bg-white ${
             isCurrentPage && href === '/ranking'
               ? 'text-neutral-1000 border-primary-400'
               : 'text-neutral-1000/20 border-neutral-200'
@@ -28,7 +28,7 @@ export default function RankingFriendsPageTab({ href }: RankingFriendsPageTabPro
       {href === '/friends' && (
         <Link
           href='/friends'
-          className={`text-[18px] font-semibold w-1/2 h-[52px] border-b-[2px] text-center leading-[52px] ${
+          className={`text-[18px] font-semibold w-1/2 h-[52px] border-b-[2px] text-center leading-[52px] bg-white ${
             isCurrentPage && href === '/friends'
               ? 'text-neutral-1000 border-primary-400'
               : 'text-neutral-1000/20 border-neutral-200'

--- a/src/components/ranking/RankingItem.tsx
+++ b/src/components/ranking/RankingItem.tsx
@@ -12,7 +12,7 @@ export default function RankingItem({ rankUser, rank, currentUser }: RankingItem
 
   return (
     <div
-      className={`${isCurrentUser ? 'bg-gradient-to-r from-[#5996E09E] from-62% to-white desktop:to-white/40 text-neutral-900' : 'bg-white desktop:bg-transparent text-neutral-1000/20 desktop:text-neutral-500'} flex flex-row justify-between items-center w-[339px] desktop:w-[810px] h-[42px] desktop:h-[92px] px-[12px] desktop:px-[60px] py-[14px] desktop:py-[33px] border-b-[1px] border-[#9EA2AD4D]/30 text-[14px] desktop:text-[20px] font-semibold`}
+      className={`${isCurrentUser ? 'bg-gradient-to-r from-[#5996E09E] from-62% to-white desktop:to-white/40 text-neutral-900' : 'bg-white desktop:bg-transparent text-neutral-1000/20 desktop:text-neutral-500'} flex flex-row justify-between items-center w-full desktop:w-[810px] h-[42px] desktop:h-[92px] px-[12px] desktop:px-[60px] py-[14px] desktop:py-[33px] border-b-[1px] border-[#9EA2AD4D]/30 text-[14px] desktop:text-[20px] font-semibold`}
     >
       <span className={isCurrentUser ? 'text-primary-400' : ''}>{rank}</span>
       <div className='flex flex-row gap-[8px] justify-start items-center desktop:w-[520px]'>

--- a/src/components/ui/buttons/FriendUrlCopyButton.tsx
+++ b/src/components/ui/buttons/FriendUrlCopyButton.tsx
@@ -18,7 +18,7 @@ export default function FriendUrlCopyButton({ currentUserId }: FriendUrlCopyButt
   return (
     <button
       onClick={handleCopyFriendUrl}
-      className='bg-primary-300 w-[339px] desktop:w-[1035px] h-[68px] desktop:h-[164px] flex justify-around desktop:justify-center items-center rounded-[8px] desktop:rounded-[30px] desktop:px-[90px] my-[20px] desktop:my-[64px] shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)]'
+      className='bg-primary-300 w-full desktop:w-[1035px] h-[68px] desktop:h-[164px] flex justify-around desktop:justify-center items-center rounded-[8px] desktop:rounded-[30px] desktop:px-[90px] my-[20px] desktop:my-[64px] shadow-[0px_4px_4px_0px_rgba(0,0,0,0.25)]'
     >
       <Image
         src='/assets/icons/pola-head.png'


### PR DESCRIPTION
## ✅ 작업 사항

- 중앙정렬 맞지 않던 부분들 개선
- 랭킹/친구 전환 탭이 콘텐츠 부분과 같이 스크롤되지 않고 고정돼있도록 수정
- 레이아웃, 콘텐츠 부분 z-index 조정
- 데스크탑에서 친구 없는 상태도 있는 상태와 동일한 컨테이너에 표시되도록 설정
