### PR TITLE
Style/ranking: 랭킹 페이지 스타일 개선사항 반영

### DIFF
--- a/src/app/(rankingFriendsTab)/layout.tsx
+++ b/src/app/(rankingFriendsTab)/layout.tsx
@@ -3,9 +3,10 @@ import RankingFriendsPageTab from '@/components/ranking/RankingFriendsPageTab';
 export default async function ChallengeLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className='flex flex-col w-full h-full'>
-      <section className='flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[151px] rounded-[61px] bg-primary-100 px-[41px] pb-[33px] z-[1] desktop:hidden'>
+      <section className='flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[151px] rounded-[61px] bg-primary-100 px-[41px] pb-[33px] z-[2] desktop:hidden'>
         <h1 className='pt-[60px] text-[18px] font-semibold text-center leading-[35px]'>랭킹</h1>
       </section>
+      <div className='fixed top-0 left-0 w-full h-[131px] bg-white z-[1] pointer-events-none' />
       <div className='relative flex flex-col w-full h-full mt-[46px] desktop:mt-0'>
         <div className='flex sticky top-[131px] w-full desktop:hidden'>
           <RankingFriendsPageTab href='/ranking' />

--- a/src/components/ranking/FriendContainer.tsx
+++ b/src/components/ranking/FriendContainer.tsx
@@ -1,6 +1,6 @@
 export default function FriendContainer({ children }: { children: React.ReactNode }) {
   return (
-    <div className='flex flex-col w-full desktop:w-[364px] desktop:rounded-[40px] desktop:shadow-[4px_4px_4px_0px_rgba(0,0,0,0.15)] desktop:bg-white desktop:px-[20px] desktop:py-[27px] desktop:mt-[36px]'>
+    <div className='flex flex-col w-full desktop:w-[364px] desktop:rounded-[40px] desktop:shadow-[4px_4px_4px_0px_rgba(0,0,0,0.15)] desktop:bg-white py-[4px] desktop:px-[20px] desktop:py-[27px] desktop:mt-[36px]'>
       <div className='hidden desktop:block'>
         <h2 className='text-[24px] text-neutral-1000 font-semibold mb-[12px]'>추가한 친구</h2>
       </div>

--- a/src/components/ranking/FriendItem.tsx
+++ b/src/components/ranking/FriendItem.tsx
@@ -9,7 +9,7 @@ export default function FriendItem({ friend, index }: FriendItemProps) {
   const { nickname, mileage } = friend;
 
   return (
-    <div className='flex flex-row justify-between items-center w-[339px] desktop:w-[316px] h-[42px] px-[12px] py-[14px] border-b-[1px] border-[#9EA2AD4D]/30 text-[14px] text-neutral-700 font-semibold'>
+    <div className='flex flex-row justify-between items-center w-full desktop:w-[316px] h-[42px] px-[12px] py-[14px] border-b-[1px] border-[#9EA2AD4D]/30 text-[14px] text-neutral-700 font-semibold'>
       <span>{index}</span>
       <span className='inline-block w-[244px]'>{nickname}</span>
       <span>{mileage}M</span>


### PR DESCRIPTION
## ✅ 작업 사항

- 랭킹페이지 스크롤시 모바일 헤더와 랭킹/친구 탭 사이 틈으로 랭킹 아이템이 보이지 않도록 개선
- 친구 아이템 수치 조정

<br/>

## 📸 스크린샷
![헤더-탭사이 스크롤 테스트](https://github.com/user-attachments/assets/996df923-0f73-4e87-93e8-0609a023fb44)


<br/>
