### PR TITLE
Feat/contents container: 마이폴라, 랭킹 콘텐츠 레이아웃 개선사항 반영

### DIFF
--- a/src/app/(rankingFriendsTab)/layout.tsx
+++ b/src/app/(rankingFriendsTab)/layout.tsx
@@ -1,6 +1,6 @@
 import RankingFriendsPageTab from '@/components/ranking/RankingFriendsPageTab';
 
-export default async function ChallengeLayout({ children }: { children: React.ReactNode }) {
+export default async function RankingFriendsTabLayout({ children }: { children: React.ReactNode }) {
   return (
     <div className='flex flex-col w-full h-full'>
       <section className='flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[151px] rounded-[61px] bg-primary-100 px-[41px] pb-[33px] z-[2] desktop:hidden'>

--- a/src/app/mypola/layout.tsx
+++ b/src/app/mypola/layout.tsx
@@ -1,12 +1,8 @@
-import React from 'react';
-
-export default async function ChallengeLayout({ children }: { children: React.ReactNode }) {
+export default async function MypolaLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className='flex flex-col h-full'>
-      <section className='flex flex-col gap-[21px] fixed w-[calc(100%+40px)] left-[-20px] top-[-20px] h-[284px] px-[41px] pb-[33px]'>
-        <h1 className='pt-[60px] desktop:pt-[110px] text-[18px] font-semibold text-center leading-[35px]'>마이폴라</h1>
-      </section>
-      <main className='flex flex-col h-full'>{children}</main>
-    </div>
+    <>
+      <h1 className='fixed top-[41px] left-0 w-full text-[18px] font-semibold text-center'>마이폴라</h1>
+      <div className='h-[calc(100dvh-85px)] overflow-y-auto'>{children}</div>
+    </>
   );
 }

--- a/src/app/mypola/layout.tsx
+++ b/src/app/mypola/layout.tsx
@@ -1,8 +1,8 @@
 export default async function MypolaLayout({ children }: { children: React.ReactNode }) {
   return (
     <>
-      <h1 className='fixed top-[41px] left-0 w-full text-[18px] font-semibold text-center'>마이폴라</h1>
-      <div className='h-[calc(100dvh-85px)] overflow-y-auto'>{children}</div>
+      <h1 className='fixed top-[41px] left-0 w-full text-[18px] font-semibold text-center desktop:hidden'>마이폴라</h1>
+      <div className='h-[calc(100dvh-85px)] desktop:h-full overflow-y-auto'>{children}</div>
     </>
   );
 }

--- a/src/components/mypola/MypolaContainer.tsx
+++ b/src/components/mypola/MypolaContainer.tsx
@@ -5,7 +5,6 @@ import { useGeolocation } from '@/hooks/user/useGeolocation';
 import MileageBar from './MileageBar';
 import { LEVEL_POLA_NAME } from '@/constants/levelInfo';
 import WeatherIcon from './WeatherIcon';
-import Image from 'next/image';
 import Mypola from './Mypola';
 
 type MypolaContainerProps = {
@@ -45,15 +44,9 @@ export default function MypolaContainer({ level, mileage, usernickname }: Mypola
           <WeatherIcon weather={weather || 'sunny'} />
         )}
       </div>
-      <div className='w-full h-[300px] flex justify-center items-end relative mb-[20px]'>
+      <div className='relative w-full h-300 flex flex-row justify-center items-end'>
         <Mypola level={level} />
-        <Image
-          src='/assets/images/mypola/mypola-shadow.webp'
-          alt='mypola-shadow'
-          width={214}
-          height={130}
-          className='z-[1] absolute left-1/2 -translate-x-1/2'
-        />
+        <div className='w-[290px] h-[52px] bg-neutral-400 rounded-[50%] z-[0] translate-y-[26px] ' />
       </div>
       <div>
         <p className='font-semibold text-neutral-1000 text-[20px] text-center mb-[32px]'>


### PR DESCRIPTION
## ✅ 작업 사항

- 마이폴라 페이지 스크롤시 헤더와 겹치지 않도록 설정
- 랭킹페이지 레이아웃 컴포넌트이름 수정

<br/>

## 📸 스크린샷
![마이폴라 스크롤테스트](https://github.com/user-attachments/assets/dd0dac79-7dfa-44f1-b278-203ecb92e8f5)


<br/>
